### PR TITLE
Money supply was incorrect due to a line left over from the PIVX fork…

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2903,7 +2903,7 @@ bool RecalculatePHRSupply(int nHeightStart)
     CBlockIndex* pindex = chainActive[nHeightStart];
     CAmount nSupplyPrev = pindex->pprev->nMoneySupply;
     if (nHeightStart == Params().Zerocoin_StartHeight())
-        nSupplyPrev = CAmount(5449796547496199);
+        nSupplyPrev = CAmount(1880313101204990);
 
     while (true) {
         if (pindex->nHeight % 1000 == 0)


### PR DESCRIPTION
…. Changed money supply for block 89999 to the correct Phore value.