### PR TITLE
Fixes bug with Zerocoin hardcoded checkpoint

### DIFF
--- a/src/accumulatorcheckpoints.cpp
+++ b/src/accumulatorcheckpoints.cpp
@@ -54,7 +54,7 @@ namespace AccumulatorCheckpoints
                     return false;
                 }
                 CBigNum bn = 0;
-                bn.SetHex(vDenomValue.get_str());
+                bn.SetDec(vDenomValue.get_str());
                 checkpoint.insert(std::make_pair(denom, bn));
             }
 


### PR DESCRIPTION
From @mrmetech
```
018-07-09 00:18:26 ERROR: CalculateAccumulatorCheckpoint: failed to initialize accumulators
2018-07-09 00:18:26 ERROR: ValidateAccumulatorCheckpoint : failed to calculate accumulator checkpoint
2018-07-09 00:18:26 ERROR: ConnectBlock: Failed to validate accumulator checkpoint for block=04e2efaa2ba70a35cdfb747df4edfe14ae2f69dcfb2bf1025c12cdddad43c492 height=408920
```

This happened because his branch had an old activation height. I was able to reproduce the bug by changing the activation height to something sooner (like block 149,999). Before merging this, can someone @tohsnoom @mrmetech verify this fix works?