### PR TITLE
PHR-18 [Qt] Console: add security warning

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -632,12 +632,16 @@ void RPCConsole::clear()
         "td.message { font-family: Courier, Courier New, Lucida Console, monospace; font-size: 12px; } " // Todo: Remove fixed font-size
         "td.cmd-request { color: #006060; } "
         "td.cmd-error { color: red; } "
+        ".secwarning { color: red; }"
         "b { color: #006060; } ");
 
     message(CMD_REPLY, (tr("Welcome to the Phore RPC console.") + "<br>" +
                            tr("Use up and down arrows to navigate history, and <b>Ctrl-L</b> to clear screen.") + "<br>" +
-                           tr("Type <b>help</b> for an overview of available commands.")),
-        true);
+                           tr("Type <b>help</b> for an overview of available commands.") +
+                           "<br><span class=\"secwarning\"><br>" +
+                           tr("WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramifications of a command.") +
+                           "</span>"),
+                           true);
 }
 
 void RPCConsole::reject()


### PR DESCRIPTION
Co-Authored-By: Jonas Schnelli <jonasschnelli@users.noreply.github.com>

This is an upstream change made by Johas Schnelli

The scope of this PR is also not to warn or disable certain private-key revealing commands (can be done in a separate PR).

![image](https://user-images.githubusercontent.com/31669092/73107136-58084e80-3eba-11ea-994f-881dbf4f2bc2.png)
