### PR TITLE
PHR-17 Upgrade path for non-HD wallets to HD

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1653,7 +1653,8 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler, const std
                 strErrors << _("Error loading wallet.dat") << "\n";
         }
 
-        if (GetBoolArg("-upgradewallet", fFirstRun)) {
+        int prev_version = pwalletMain->GetVersion();
+        if (GetBoolArg("-upgradewallet", fFirstRun) || (words.size() !=0 && !pwalletMain->IsHDEnabled() && CheckIfWalletDatExists())) {
             int nMaxVersion = GetArg("-upgradewallet", 0);
             if (nMaxVersion == 0) // the -upgradewallet without argument case
             {
@@ -1673,7 +1674,6 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler, const std
             if (GetArg("-mnemonicpassphrase", "").size() > 256)
                 return InitError(_("Mnemonic passphrase is too long, must be at most 256 characters"));
             // generate a new master key
-            InitError(_("test 2"));;
             pwalletMain->GenerateNewHDChain(words);
             // ensure this wallet.dat can only be opened by clients supporting HD
             pwalletMain->SetMinVersion(FEATURE_HD);

--- a/src/keystore.cpp
+++ b/src/keystore.cpp
@@ -200,3 +200,10 @@ CKeyID GetKeyForDestination(const CKeyStore& store, const CTxDestination& dest)
     }
     return CKeyID();
 }
+
+bool HaveKey(const CKeyStore& store, const CKey& key)
+{
+    CKey key2;
+    key2.Set(key.begin(), key.end(), !key.IsCompressed());
+    return store.HaveKey(key.GetPubKey().GetID()) || store.HaveKey(key2.GetPubKey().GetID());
+}

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -133,4 +133,7 @@ typedef std::map<CKeyID, std::pair<CPubKey, std::vector<unsigned char> > > Crypt
 /** Return the CKeyID of the key involved in a script (if there is a unique one). */
 CKeyID GetKeyForDestination(const CKeyStore& store, const CTxDestination& dest);
 
+/** Checks if a CKey is in the given CKeyStore compressed or otherwise*/
+bool HaveKey(const CKeyStore& store, const CKey& key);
+
 #endif // BITCOIN_KEYSTORE_H

--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -96,7 +96,6 @@ AskPassphraseDialog::~AskPassphraseDialog()
 
 void AskPassphraseDialog::accept()
 {
-    SecureString oldpass, newpass1, newpass2;
     if (!model)
         return;
     oldpass.reserve(MAX_PASSPHRASE_SIZE);

--- a/src/qt/askpassphrasedialog.h
+++ b/src/qt/askpassphrasedialog.h
@@ -6,6 +6,7 @@
 #define BITCOIN_QT_ASKPASSPHRASEDIALOG_H
 
 #include <QDialog>
+#include "allocators.h"
 
 class WalletModel;
 
@@ -33,12 +34,14 @@ public:
     ~AskPassphraseDialog();
 
     void accept();
+    SecureString getPassword() { return oldpass; }
 
 private:
     Ui::AskPassphraseDialog* ui;
     Mode mode;
     WalletModel* model;
     bool fCapsLock;
+    SecureString oldpass, newpass1, newpass2;
 
 private slots:
     void textChanged();

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -700,6 +700,7 @@ bool BitcoinGUI::addWallet(const QString& name, WalletModel* walletModel)
     if (!walletFrame)
         return false;
     setWalletActionsEnabled(true);
+    rpcConsole->setWalletModel(walletModel);
     return walletFrame->addWallet(name, walletModel);
 }
 

--- a/src/qt/forms/rpcconsole.ui
+++ b/src/qt/forms/rpcconsole.ui
@@ -1606,7 +1606,37 @@
          </property>
         </widget>
        </item>
-       <item row="14" column="0">
+       <item row="14" column="0" colspan="2">
+        <widget class="QPushButton" name="btn_convert_to_hd_Wallet">
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>23</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Upgrade non-hd wallet to hd</string>
+         </property>
+        </widget>
+       </item>
+       <item row="14" column="2">
+        <widget class="QLabel" name="label_convert_to_hd_Wallet_command">
+         <property name="text">
+          <string>-rescan:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="14" column="3">
+        <widget class="QLabel" name="label_convert_to_hd_Wallet">
+         <property name="text">
+          <string>Upgrade non-hd wallet to hd</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="15" column="0">
         <spacer name="verticalSpacer_repair2">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -9,6 +9,7 @@
 
 #include "bantablemodel.h"
 #include "clientmodel.h"
+#include "walletmodel.h"
 #include "guiutil.h"
 #include "peertablemodel.h"
 
@@ -17,6 +18,11 @@
 #include "rpcclient.h"
 #include "rpcserver.h"
 #include "util.h"
+
+#include "init.h"
+#include <startoptionsmain.h>
+#include "askpassphrasedialog.h"
+
 #ifdef ENABLE_WALLET
 #include "wallet/wallet.h"
 #endif // ENABLE_WALLET
@@ -261,6 +267,7 @@ void RPCExecutor::request(const QString& command)
 RPCConsole::RPCConsole(QWidget* parent) : QDialog(parent),
                                           ui(new Ui::RPCConsole),
                                           clientModel(0),
+                                          walletModel(0),
                                           historyPtr(0),
                                           cachedNodeid(-1),
                                           peersTableContextMenu(0),
@@ -289,6 +296,7 @@ RPCConsole::RPCConsole(QWidget* parent) : QDialog(parent),
     connect(ui->btn_upgradewallet, SIGNAL(clicked()), this, SLOT(walletUpgrade()));
     connect(ui->btn_reindex, SIGNAL(clicked()), this, SLOT(walletReindex()));
     connect(ui->btn_resync, SIGNAL(clicked()), this, SLOT(walletResync()));
+    connect(ui->btn_convert_to_hd_Wallet, SIGNAL(clicked()), this, SLOT(walletUpgradeToHd()));
 
     // set library version labels
     ui->openSSLVersion->setText(SSLeay_version(SSLEAY_VERSION));
@@ -512,6 +520,11 @@ void RPCConsole::setClientModel(ClientModel* model)
     }
 }
 
+void RPCConsole::setWalletModel(WalletModel* walletModel)
+{
+    this->walletModel = walletModel;
+}
+
 static QString categoryClass(int category)
 {
     switch (category) {
@@ -584,6 +597,106 @@ void RPCConsole::walletResync()
 
     // Restart and resync
     buildParameterlist(RESYNC);
+}
+
+/** Restart wallet with "-resync" and upgrade to a HD wallet*/
+void RPCConsole::walletUpgradeToHd()
+{
+    QString upgradeWarning = tr("This will convert you non-HD wallet to a HD wallet<br /><br />");
+    upgradeWarning +=   tr("Make sure to make a backup of your wallet ahead of time<br /><br />");
+    upgradeWarning +=   tr("You shouldn't force close the wallet while this is running<br /><br />");
+    upgradeWarning +=   tr("Do you want to continue?.<br />");
+    QMessageBox::StandardButton retval = QMessageBox::question(this, tr("Confirm upgrade to HD wallet"),
+                                                               upgradeWarning,
+                                                               QMessageBox::Yes | QMessageBox::Cancel,
+                                                               QMessageBox::Cancel);
+
+    if (retval != QMessageBox::Yes) {
+        // Resync canceled
+        return;
+    }
+
+    if (IsInitialBlockDownload()) {
+        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Cannot set a new HD seed while still in Initial Block Download");
+    }
+
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
+    // Do not do anything to HD wallets
+    if (pwalletMain->IsHDEnabled()) {
+        throw JSONRPCError(RPC_WALLET_ERROR, "Cannot upgrade a wallet to hd if It is already upgraded to hd.");
+    }
+
+    std::vector<std::string> words;
+    SecureString strWalletPass;
+    strWalletPass.reserve(100);
+
+    int prev_version = pwalletMain->GetVersion();
+
+    int nMaxVersion = GetArg("-upgradewallet", 0);
+    if (nMaxVersion == 0) // the -upgradewallet without argument case
+    {
+        LogPrintf("Performing wallet upgrade to %i\n", FEATURE_LATEST);
+        nMaxVersion = CLIENT_VERSION;
+        pwalletMain->SetMinVersion(FEATURE_LATEST); // permanently upgrade the wallet immediately
+    } else
+        LogPrintf("Allowing wallet upgrade up to %i\n", nMaxVersion);
+    if (nMaxVersion < pwalletMain->GetVersion()) {
+        throw JSONRPCError(RPC_WALLET_ERROR, "Cannot downgrade wallet");
+    }
+
+    pwalletMain->SetMaxVersion(nMaxVersion);
+
+    // Do not upgrade versions to any version between HD_SPLIT and FEATURE_PRE_SPLIT_KEYPOOL unless already supporting HD_SPLIT
+    int max_version = pwalletMain->GetVersion();
+    if (!pwalletMain->CanSupportFeature(FEATURE_HD) && max_version >=FEATURE_HD && max_version < FEATURE_PRE_SPLIT_KEYPOOL) {
+        throw JSONRPCError(RPC_WALLET_ERROR, "Cannot upgrade a non HD split wallet without upgrading to support pre split keypool. Please use -upgradewallet=169900 or -upgradewallet with no version specified.");
+    }
+
+    bool hd_upgrade = false;
+    bool split_upgrade = false;
+    if (pwalletMain->CanSupportFeature(FEATURE_HD) && !pwalletMain->IsHDEnabled()) {
+        LogPrintf("Upgrading wallet to HD\n");
+        pwalletMain->SetMinVersion(FEATURE_HD);
+
+        if (walletModel->getEncryptionStatus() == WalletModel::Locked || walletModel->getEncryptionStatus() == WalletModel::UnlockedForAnonymizationOnly) {
+            AskPassphraseDialog dlg(AskPassphraseDialog::Unlock, this, walletModel);
+            dlg.exec();
+            strWalletPass = dlg.getPassword();
+        } else {
+            strWalletPass = std::string().c_str();
+        }
+
+        StartOptionsMain dlg(nullptr);
+        dlg.exec();
+        words = dlg.getWords();
+
+        pwalletMain->GenerateNewHDChain(words, strWalletPass);
+
+        hd_upgrade = true;
+    }
+
+    // Upgrade to HD chain split if necessary
+    if (pwalletMain->CanSupportFeature(FEATURE_HD)) {
+        LogPrintf("Upgrading wallet to use HD chain split\n");
+        pwalletMain->SetMinVersion(FEATURE_PRE_SPLIT_KEYPOOL);
+        split_upgrade = FEATURE_HD > prev_version;
+    }
+
+    // Mark all keys currently in the keypool as pre-split
+    if (split_upgrade) {
+        pwalletMain->MarkPreSplitKeys();
+    }
+
+    // Regenerate the keypool if upgraded to HD
+    if (hd_upgrade) {
+        if (!pwalletMain->TopUpKeyPool()) {
+            throw JSONRPCError(RPC_WALLET_ERROR, "Unable to generate keys\n");
+        }
+    }
+
+    buildParameterlist(RESCAN);
+
 }
 
 /** Build command-line parameter list for restart */

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -14,6 +14,7 @@
 #include <QCompleter>
 
 class ClientModel;
+class WalletModel;
 class RPCTimerInterface;
 
 namespace Ui
@@ -36,6 +37,7 @@ public:
     ~RPCConsole();
 
     void setClientModel(ClientModel* model);
+    void setWalletModel(WalletModel* walletModel);
 
     enum MessageClass {
         MC_ERROR,
@@ -80,6 +82,7 @@ public slots:
     void walletUpgrade();
     void walletReindex();
     void walletResync();
+    void walletUpgradeToHd();
 
     void reject();
     void message(int category, const QString& message, bool html = false);
@@ -146,6 +149,7 @@ private:
 
     Ui::RPCConsole* ui;
     ClientModel* clientModel;
+    WalletModel* walletModel;
     QStringList history;
     int historyPtr;
     NodeId cachedNodeid;

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "walletframe.h"
+#include "rpcconsole.h"
 
 #include "bitcoingui.h"
 #include "walletview.h"

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -439,8 +439,10 @@ static const CRPCCommand vRPCCommands[] =
         {"wallet", "settxfee", &settxfee, true, false, true},
         {"wallet", "signmessage", &signmessage, true, false, true},
         {"wallet", "walletlock", &walletlock, true, false, true},
+        {"wallet", "upgradetohd", &upgradetohd, true, false, true},
         {"wallet", "walletpassphrasechange", &walletpassphrasechange, true, false, true},
         {"wallet", "walletpassphrase", &walletpassphrase, true, false, true},
+
 
         {"zerocoin", "getzerocoinbalance", &getzerocoinbalance, false, false, true},
         {"zerocoin", "listmintedzerocoins", &listmintedzerocoins, false, false, true},

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -236,6 +236,7 @@ extern UniValue listaccounts(const UniValue& params, bool fHelp);
 extern UniValue listsinceblock(const UniValue& params, bool fHelp);
 extern UniValue gettransaction(const UniValue& params, bool fHelp);
 extern UniValue backupwallet(const UniValue& params, bool fHelp);
+extern UniValue upgradetohd(const UniValue& params, bool fHelp);
 extern UniValue keypoolrefill(const UniValue& params, bool fHelp);
 extern UniValue walletpassphrase(const UniValue& params, bool fHelp);
 extern UniValue walletpassphrasechange(const UniValue& params, bool fHelp);

--- a/src/wallet/crypter.h
+++ b/src/wallet/crypter.h
@@ -138,10 +138,13 @@ protected:
 
     //! will encrypt previously unencrypted keys
     bool EncryptKeys(CKeyingMaterial& vMasterKeyIn);
+
     bool EncryptHDChain(const CKeyingMaterial& vMasterKeyIn);
+    bool EncryptHDChainUpgrade(const CKeyingMaterial& vMasterKeyIn, const CHDChain& chain);
     bool DecryptHDChain(CHDChain& hdChainRet) const;
     bool SetHDChain(const CHDChain& chain);
     bool SetCryptedHDChain(const CHDChain& chain);
+
     bool Unlock(const CKeyingMaterial& vMasterKeyIn);
 
 public:

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2170,7 +2170,7 @@ UniValue getwalletinfo(const UniValue& params, bool fHelp)
         obj.push_back(Pair("hdchainid", hdChainCurrent.GetID().GetHex()));
         obj.push_back(Pair("hdaccountcount", (int64_t)hdChainCurrent.CountAccounts()));
         UniValue accounts(UniValue::VARR);
-        for (int i = 0; i < hdChainCurrent.CountAccounts(); ++i)
+        for (size_t i = 0; i < hdChainCurrent.CountAccounts(); ++i)
         {
             CHDAccount acc;
             UniValue account(UniValue::VOBJ);
@@ -2561,6 +2561,113 @@ UniValue multisend(const UniValue& params, bool fHelp)
     }
     return printMultiSend();
 }
+
+UniValue upgradetohd(const UniValue& params, bool fHelp)
+{
+
+    if (fHelp || params.size() == 0) {
+        throw std::runtime_error(
+                "upgradetohd ( \"mnemonicwords\" \"password\" )\n"
+                "\nNon-HD wallets will not be upgraded to being a HD wallet. Wallets that are already\n"
+                "\nNote that you will need to MAKE A NEW BACKUP of your wallet after setting the HD wallet mnemonic.\n"
+                "\nArguments:\n"
+                "1. \"words\"               (string, optional) The WIF private key to use as the new HD seed; if not provided a random seed will be used.\n"
+                "                             The mnemonic value can be retrieved using the dumpwallet command. It is the private key marked hdmaster=1\n"
+                "2. \"password\"               (boolean, optional) If your wallet is encrypted you must have your password here\n"
+
+                "\nExamples:\n"
+                + HelpExampleCli("upgradetohd", "")
+                + HelpExampleCli("upgradetohd", "\"mnemonicwords\"")
+                + HelpExampleCli("upgradetohd", "\"mnemonicwords\" \"password\""));
+    }
+
+    if (IsInitialBlockDownload()) {
+        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Cannot set a new HD seed while still in Initial Block Download");
+    }
+
+    if (params.size() == 1 && pwalletMain->IsLocked()) {
+        throw JSONRPCError(RPC_WALLET_ERROR, "Cannot upgrade a encrypted wallet to hd without the password");
+    }
+
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
+    // Do not do anything to HD wallets
+    if (pwalletMain->IsHDEnabled()) {
+        throw JSONRPCError(RPC_WALLET_ERROR, "Cannot upgrade a wallet to hd if It is already upgraded to hd.");
+    }
+
+    EnsureWalletIsUnlocked(pwalletMain);
+
+    std::string words = params[0].get_str();
+
+    int prev_version = pwalletMain->GetVersion();
+
+    int nMaxVersion = GetArg("-upgradewallet", 0);
+    if (nMaxVersion == 0) // the -upgradewallet without argument case
+    {
+        LogPrintf("Performing wallet upgrade to %i\n", FEATURE_LATEST);
+        nMaxVersion = CLIENT_VERSION;
+        pwalletMain->SetMinVersion(FEATURE_LATEST); // permanently upgrade the wallet immediately
+    } else
+        LogPrintf("Allowing wallet upgrade up to %i\n", nMaxVersion);
+    if (nMaxVersion < pwalletMain->GetVersion()) {
+        throw JSONRPCError(RPC_WALLET_ERROR, "Cannot downgrade wallet");
+    }
+
+    pwalletMain->SetMaxVersion(nMaxVersion);
+
+    // Do not upgrade versions to any version between HD_SPLIT and FEATURE_PRE_SPLIT_KEYPOOL unless already supporting HD_SPLIT
+    int max_version = pwalletMain->GetVersion();
+    if (!pwalletMain->CanSupportFeature(FEATURE_HD) && max_version >=FEATURE_HD && max_version < FEATURE_PRE_SPLIT_KEYPOOL) {
+        throw JSONRPCError(RPC_WALLET_ERROR, "Cannot upgrade a non HD split wallet without upgrading to support pre split keypool. Please use -upgradewallet=169900 or -upgradewallet with no version specified.");
+    }
+
+    bool hd_upgrade = false;
+    bool split_upgrade = false;
+    if (pwalletMain->CanSupportFeature(FEATURE_HD) && !pwalletMain->IsHDEnabled()) {
+        LogPrintf("Upgrading wallet to HD\n");
+        pwalletMain->SetMinVersion(FEATURE_HD);
+
+        // generate a new master key
+        SecureString strWalletPass;
+        strWalletPass.reserve(100);
+
+        // TODO: get rid of this .c_str() by implementing SecureString::operator=(std::string)
+        // Alternately, find a way to make params[0] mlock()'d to begin with.
+        if (params.size() < 2){
+            strWalletPass = std::string().c_str();
+        } else {
+            strWalletPass = params[1].get_str().c_str();
+        }
+
+        pwalletMain->GenerateNewHDChain(words, strWalletPass);
+
+        hd_upgrade = true;
+    }
+
+    // Upgrade to HD chain split if necessary
+    if (pwalletMain->CanSupportFeature(FEATURE_HD)) {
+        LogPrintf("Upgrading wallet to use HD chain split\n");
+        pwalletMain->SetMinVersion(FEATURE_PRE_SPLIT_KEYPOOL);
+        split_upgrade = FEATURE_HD > prev_version;
+    }
+
+    // Mark all keys currently in the keypool as pre-split
+    if (split_upgrade) {
+        pwalletMain->MarkPreSplitKeys();
+    }
+    // Regenerate the keypool if upgraded to HD
+    if (hd_upgrade) {
+        if (!pwalletMain->TopUpKeyPool()) {
+            throw JSONRPCError(RPC_WALLET_ERROR, "Unable to generate keys\n");
+        }
+    }
+
+    pwalletMain->ScanForWalletTransactions(chainActive.Genesis(), true);
+
+    return NullUniValue;
+}
+
 UniValue getzerocoinbalance(const UniValue& params, bool fHelp)
 {
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -416,6 +416,50 @@ bool CWallet::LoadMultiSig(const CScript& dest)
     return CCryptoKeyStore::AddMultiSig(dest);
 }
 
+bool CWallet::UpgradeHdChainEncrypted(const SecureString& strWalletPassphrase, const CHDChain& chain)
+{
+    SecureString strWalletPassphraseFinal;
+
+    strWalletPassphraseFinal = strWalletPassphrase;
+
+    // must get current HD chain before EncryptKeys
+    CHDChain hdChainCurrent;
+    hdChainCurrent = chain;
+
+    CCrypter crypter;
+    CKeyingMaterial vMasterKey;
+
+    {
+        LOCK(cs_wallet);
+        BOOST_FOREACH (const MasterKeyMap::value_type& pMasterKey, mapMasterKeys) {
+            if (!crypter.SetKeyFromPassphrase(strWalletPassphraseFinal, pMasterKey.second.vchSalt, pMasterKey.second.nDeriveIterations, pMasterKey.second.nDerivationMethod))
+                return false;
+            if (!crypter.Decrypt(pMasterKey.second.vchCryptedKey, vMasterKey)) {
+                continue; // try another master key
+            }
+
+
+            assert(EncryptHDChainUpgrade(vMasterKey, hdChainCurrent));
+
+            CHDChain hdChainCrypted;
+            assert(GetHDChain(hdChainCrypted));
+
+
+            LogPrintf("EncryptWallet -- current seed: '%s'\n", HexStr(hdChainCurrent.GetSeed()).c_str());
+            LogPrintf("EncryptWallet -- crypted seed: '%s'\n", HexStr(hdChainCrypted.GetSeed()).c_str());
+
+            // ids should match, seed hashes should not
+            assert(hdChainCurrent.GetID() == hdChainCrypted.GetID());
+            assert(hdChainCurrent.GetSeedHash() != hdChainCrypted.GetSeedHash());
+
+            if (SetCryptedHDChain(hdChainCrypted, false)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 bool CWallet::Unlock(const SecureString& strWalletPassphrase, bool anonymizeOnly)
 {
     SecureString strWalletPassphraseFinal;
@@ -426,7 +470,6 @@ bool CWallet::Unlock(const SecureString& strWalletPassphrase, bool anonymizeOnly
     }
 
     strWalletPassphraseFinal = strWalletPassphrase;
-
 
     CCrypter crypter;
     CKeyingMaterial vMasterKey;
@@ -815,7 +858,7 @@ bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
     return true;
 }
 
-void CWallet::GenerateNewHDChain(const std::vector<std::string>& words)
+void CWallet::GenerateNewHDChain(const std::string& words, const SecureString& strWalletPassphrase)
 {
     CHDChain newHdChain;
 
@@ -832,9 +875,10 @@ void CWallet::GenerateNewHDChain(const std::vector<std::string>& words)
 
         // NOTE: empty mnemonic means "generate a new one for me"
         //std::string strMnemonic = GetArg("-mnemonic", "");
+        // if this is true words would already be a string now
         std::string strMnemonic;
         if (words.size() !=0) {
-            strMnemonic = join(words," ");
+            strMnemonic = words;
         } else {
             strMnemonic = GetArg("-mnemonic", "");
         }
@@ -850,13 +894,27 @@ void CWallet::GenerateNewHDChain(const std::vector<std::string>& words)
     }
     newHdChain.Debug(__func__);
 
-    if (!SetHDChain(newHdChain, false))
-        throw std::runtime_error(std::string(__func__) + ": SetHDChain failed");
+    if (IsCrypted()) {
+        if (!UpgradeHdChainEncrypted(strWalletPassphrase, newHdChain))
+            throw std::runtime_error(std::string(__func__) + ": SetCryptedHDChain failed");
+    }
+    else {
+        if (!SetHDChain(newHdChain, false))
+            throw std::runtime_error(std::string(__func__) + ": SetHDChain failed");
+    }
+
 
     // clean up
     mapArgs.erase("-hdseed");
     mapArgs.erase("-mnemonic");
     mapArgs.erase("-mnemonicpassphrase");
+}
+
+void CWallet::GenerateNewHDChain(const std::vector<std::string>& words, const SecureString& strWalletPassphrase)
+{
+    std::string strMnemonic;
+    strMnemonic = join(words," ");
+    return GenerateNewHDChain(strMnemonic, strWalletPassphrase);
 }
 
 bool CWallet::SetHDChain(const CHDChain& chain, bool memonly)
@@ -883,9 +941,11 @@ bool CWallet::SetCryptedHDChain(const CHDChain& chain, bool memonly)
         if (!fFileBacked)
             return false;
         if (pwalletdbEncryption) {
+
             if (!pwalletdbEncryption->WriteCryptedHDChain(chain))
                 throw std::runtime_error(std::string(__func__) + ": WriteCryptedHDChain failed");
         } else {
+
             if (!CWalletDB(strWalletFile).WriteCryptedHDChain(chain))
                 throw std::runtime_error(std::string(__func__) + ": WriteCryptedHDChain failed");
         }
@@ -3724,6 +3784,12 @@ bool CWallet::NewKeyPool()
             walletdb.ErasePool(nIndex);
         }
         setExternalKeyPool.clear();
+
+        for (int64_t nIndex : set_pre_split_keypool) {
+            walletdb.ErasePool(nIndex);
+        }
+        set_pre_split_keypool.clear();
+
         if (!TopUpKeyPool())
             return false;
 
@@ -3736,7 +3802,7 @@ bool CWallet::NewKeyPool()
 size_t CWallet::KeypoolCountExternalKeys()
 {
     AssertLockHeld(cs_wallet); // setExternalKeyPool
-    return setExternalKeyPool.size();
+    return setExternalKeyPool.size() + set_pre_split_keypool.size();
 }
 
 size_t CWallet::KeypoolCountInternalKeys()
@@ -3796,7 +3862,7 @@ bool CWallet::TopUpKeyPool(unsigned int kpSize)
             } else {
                 setExternalKeyPool.insert(nEnd);
             }
-            LogPrintf("keypool added key %d, size=%u, internal=%d\n", nEnd, setInternalKeyPool.size() + setExternalKeyPool.size(), fInternal);
+            LogPrintf("keypool added key %d, size=%u, internal=%d\n", nEnd, setInternalKeyPool.size() + setExternalKeyPool.size() + set_pre_split_keypool.size(), fInternal);
             double dProgress = 100.f * nEnd / (nTargetSize + 1);
             std::string strMsg = strprintf(_("Loading wallet... (%3.2f %%)"), dProgress);
             uiInterface.InitMessage(strMsg);
@@ -3816,7 +3882,7 @@ void CWallet::ReserveKeyFromKeyPool(int64_t& nIndex, CKeyPool& keypool, bool fIn
             TopUpKeyPool();
 
         fInternal = fInternal && IsHDEnabled();
-        std::set<int64_t>& setKeyPool = fInternal ? setInternalKeyPool : setExternalKeyPool;
+        std::set<int64_t>& setKeyPool = set_pre_split_keypool.empty() ? (fInternal ? setInternalKeyPool : setExternalKeyPool) : set_pre_split_keypool;
         // Get the oldest key
         if (setKeyPool.empty())
             return;
@@ -3831,7 +3897,8 @@ void CWallet::ReserveKeyFromKeyPool(int64_t& nIndex, CKeyPool& keypool, bool fIn
         if (!HaveKey(keypool.vchPubKey.GetID())) {
             throw std::runtime_error(std::string(__func__) + ": unknown key in key pool");
         }
-        if (keypool.fInternal != fInternal) {
+        // If the key was pre-split keypool, we don't care about what type it is
+        if (set_pre_split_keypool.size() == 0 && keypool.fInternal != fInternal) {
             throw std::runtime_error(std::string(__func__) + ": keypool entry misclassified");
         }
         assert(keypool.vchPubKey.IsValid());
@@ -3857,6 +3924,8 @@ void CWallet::ReturnKey(int64_t nIndex, bool fInternal)
         LOCK(cs_wallet);
         if (fInternal) {
             setInternalKeyPool.insert(nIndex);
+        } else if (!set_pre_split_keypool.empty()) {
+            set_pre_split_keypool.insert(nIndex);
         } else {
             setExternalKeyPool.insert(nIndex);
         }
@@ -3896,19 +3965,18 @@ int64_t CWallet::GetOldestKeyPoolTime()
 {
     LOCK(cs_wallet);
 
-    // if the keypool is empty, return <NOW>
-    if (setExternalKeyPool.empty() && setInternalKeyPool.empty())
-        return GetTime();
     CWalletDB walletdb(strWalletFile);
-    int64_t oldestKey = -1;
 
+    // test this
     // load oldest key from keypool, get time and return
+    int64_t oldestKey = GetOldestKeyInPool(setExternalKeyPool, walletdb);
     if (!setInternalKeyPool.empty()) {
         oldestKey = std::max(GetOldestKeyInPool(setInternalKeyPool, walletdb), oldestKey);
+        if (!set_pre_split_keypool.empty()) {
+            oldestKey = std::max(GetOldestKeyInPool(set_pre_split_keypool, walletdb), oldestKey);
+        }
     }
-    if (!setExternalKeyPool.empty()) {
-        oldestKey = std::max(GetOldestKeyInPool(setExternalKeyPool, walletdb), oldestKey);
-    }
+
     return oldestKey;
 }
 
@@ -4349,6 +4417,24 @@ bool CWallet::GetDestData(const CTxDestination& dest, const std::string& key, st
     return false;
 }
 
+void CWallet::MarkPreSplitKeys()
+{
+    CWalletDB walletdb(strWalletFile);
+    for (auto it = setExternalKeyPool.begin(); it != setExternalKeyPool.end();) {
+        int64_t index = *it;
+        CKeyPool keypool;
+        if (!walletdb.ReadPool(index, keypool)) {
+            throw std::runtime_error(std::string(__func__) + ": read keypool entry failed");
+        }
+        keypool.m_pre_split = true;
+        if (!walletdb.WritePool(index, keypool)) {
+            throw std::runtime_error(std::string(__func__) + ": writing modified keypool entry failed");
+        }
+        set_pre_split_keypool.insert(index);
+        it = setExternalKeyPool.erase(it);
+    }
+}
+
 // CWallet::AutoZeromint() gets called with each new incoming block
 void CWallet::AutoZeromint()
 {
@@ -4663,6 +4749,7 @@ bool CWallet::MultiSend()
 CKeyPool::CKeyPool()
 {
     nTime = GetTime();
+    m_pre_split = false;
 }
 
 CKeyPool::CKeyPool(const CPubKey& vchPubKeyIn, bool fInternalIn)
@@ -4670,6 +4757,7 @@ CKeyPool::CKeyPool(const CPubKey& vchPubKeyIn, bool fInternalIn)
     nTime = GetTime();
     vchPubKey = vchPubKeyIn;
     fInternal = fInternalIn;
+    m_pre_split = false;
 }
 
 CWalletKey::CWalletKey(int64_t nExpires)

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -49,39 +49,6 @@ enum DBErrors {
     DB_NEED_REWRITE
 };
 
-
-// todo: remove this later
-/* simple hd chain data model
-class CHDChain
-{
-public:
-    uint32_t nExternalChainCounter;
-    CKeyID masterKeyID; //!< master key hash160
-
-    static const int CURRENT_VERSION = 1;
-    int nVersion;
-
-    CHDChain() { SetNull(); }
-    ADD_SERIALIZE_METHODS;
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion)
-    {
-        READWRITE(this->nVersion);
-        nVersion = this->nVersion;
-        READWRITE(nExternalChainCounter);
-        READWRITE(masterKeyID);
-    }
-
-    void SetNull()
-    {
-        nVersion = CHDChain::CURRENT_VERSION;
-        nExternalChainCounter = 0;
-        masterKeyID.SetNull();
-    }
-};
-*/
-
-
 class CKeyMetadata
 {
 public:


### PR DESCRIPTION
What is this PR, this pr allows for an upgrade path for non-HD wallets to HD.

Some of the work for this PR was done in bitcoins PR and the other half @mrmetech or me. This implementation supports the upgrade of both non-encrypted and encrypted wallets were bitcoin only supports none encrypted wallets.

**WHY**
The reason why you would want this is that is makes upgrading to a HD wallet a lot easier than before where you would have to spend a good bit of time, but more importantly, know what you're doing. This PR is meant to make upgrading to HD wallets a lot easier for the average user, so I have added a GUI for it and RPC command. having An HD wallet also makes keeping your coins safe from random things that could occur like your wallet is corrupted you could recover your coins by just restoring you wallet from the words. _You would have to have moved your coins from an old address to a new one generated from your HD words first._

**IMAGES OF THE CHANGES**

As you see in this image a new button is here called upgrade non-HD wallet to HD. Once you click this it will ask you for your password your wallet is encrypted, after that it will bring up the new mnemonic setup code I wrote from another PR, you can restore from your previous words or make new words if you never had a HD wallet before.
![image](https://user-images.githubusercontent.com/31669092/75505196-cf3c7100-5997-11ea-8f10-ed743f31188b.png)

I also added a new RPC command called upgrade to HD, You will need to enter your mnemonic words in a stringe and your password for examle you would enter something like this into the command line
`upgradetohd "cat dog cricket computer laptop mushroom answer candy boat pond example coil train ticket ticket green bird elegant bird jazz play dog real morning" true "my password"`
![image](https://user-images.githubusercontent.com/31669092/75505355-2a6e6380-5998-11ea-9568-e03e80192792.png)


**Q&A:**
**Q:** Didn't bitcoin already implement this in Bitcoin 17
**A:** Yes and no they did implement a way to upgrade a non-HD wallet to a HD wallet, the issue with it, is the way it was implemented only supports upgrading non-encrypted wallets, which is a major issue for people who want to upgrade to HD saying that the first thing most people did was encrypt there wallet. Although in the original PR there was no mention that it didn't support encrypted wallets there were at least three issues on the bitcoin repo which had talked about this and reported this issue. 

The reason users couldn't upgrade if their wallet was encrypted was that in order to upgrade you would have to generate the new keys, which new keys can not be added if the wallet is locked. It is more complicated than that, but that is a more simple and first issue you would run into.